### PR TITLE
Bug Fix: VM Device Types

### DIFF
--- a/src/pyats/contrib/creators/netbox.py
+++ b/src/pyats/contrib/creators/netbox.py
@@ -561,6 +561,13 @@ class Netbox(TestbedCreator):
             self._set_value_if_exists(device_data, "platform", device_platform)
             self._set_value_if_exists(device_data, "type", 
                             self._get_info(device, ["device_type", "model"]))
+
+            # NetBox Virtual Machines don't have a "device_type" attribute, but pyATS requires
+            # one. If missing, construct a type from Platform + Role
+            if "type" not in device_data.keys(): 
+                role_name = self._get_info(device, ["role", "name"])
+                platform_name = self._get_info(device, ["platform", "name"])
+                device_data["type"] = "{platform} - {role}".format(platform = platform_name, role = role_name)
             
             # Initialize connection data
             connections = device_data.setdefault("connections", {})


### PR DESCRIPTION
Virtual machines in NB lack a device type, but the testbed requires one.