### PR TITLE
Fixed a syntax error with logging

### DIFF
--- a/src/pyats/contrib/creators/netbox.py
+++ b/src/pyats/contrib/creators/netbox.py
@@ -665,7 +665,7 @@ class Netbox(TestbedCreator):
                                             interface["type"]
                                         ))
                     if current.get('type') is None:
-                        logger.info("{device_name} interface {interface_name.lower()} is not valid, skipping".format(device_name=device_name))
+                        logger.info("{device_name} interface {interface_name} is not valid, skipping".format(device_name=device_name, interface_name=interface_name.lower()))
                         del interfaces[interface_name]
                         continue
                     


### PR DESCRIPTION
When building a testbed from netbox, I was receiving this error:

```
Traceback (most recent call last):
  File "src/pyats/cli/base.py", line 207, in pyats.cli.base.Command.main
  File "src/pyats/cli/base.py", line 337, in pyats.cli.base.CommandWithSubcommands.run
  File "src/genie/cli/commands/create_testbed.py", line 34, in genie.cli.commands.create_testbed.CreateTestbed.run
  File "/home/fclements/.venv/network_automation/lib/python3.5/site-packages/pyats/contrib/creators/creator.py", line 208, in to_testbed_file
    testbed = self._generate()
  File "/home/fclements/.venv/network_automation/lib/python3.5/site-packages/pyats/contrib/creators/netbox.py", line 668, in _generate
    logger.info("{device_name} interface {interface_name.lower()} is not valid, skipping".format(device_name=device_name))
KeyError: 'interface_name'


'interface_name'
```

Fixed the logging line mentioned in the error.