### PR TITLE
fixed UTs for pyats.contrib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
+# Cython files
+*.c
 *.so
 
 # Distribution / packaging

--- a/src/pyats/contrib/creators/tests/test_ansible.py
+++ b/src/pyats/contrib/creators/tests/test_ansible.py
@@ -7,6 +7,8 @@ from pyats.utils import secret_strings
 class TestAnsible(TestCase):
 
     maxDiff = None
+    # set default pyats configuration
+    secret_strings.cfg = Configuration()
 
     def setUp(self):
         self.inventory = """[all:vars]
@@ -175,9 +177,6 @@ ansible_become_pass=Cisc0123
     platform: ios
     type: iosxe
 """ 
-        # set default pyats configuration
-        config = Configuration()
-        secret_strings.cfg = config
         creator = Ansible(inventory_name=self.inventory_file, 
                                                         encode_password=True)
         creator.to_testbed_file(self.output)

--- a/src/pyats/contrib/creators/tests/test_ansible.py
+++ b/src/pyats/contrib/creators/tests/test_ansible.py
@@ -1,8 +1,13 @@
-from ..ansible import Ansible
+from pyats.contrib.creators.ansible import Ansible
 from unittest import TestCase, main
 from pyats.topology import Testbed
+from pyats.datastructures import Configuration
+from pyats.utils import secret_strings
 
 class TestAnsible(TestCase):
+
+    maxDiff = None
+
     def setUp(self):
         self.inventory = """[all:vars]
 ansible_connection=network_cli
@@ -170,6 +175,9 @@ ansible_become_pass=Cisc0123
     platform: ios
     type: iosxe
 """ 
+        # set default pyats configuration
+        config = Configuration()
+        secret_strings.cfg = config
         creator = Ansible(inventory_name=self.inventory_file, 
                                                         encode_password=True)
         creator.to_testbed_file(self.output)

--- a/src/pyats/contrib/creators/tests/test_creator.py
+++ b/src/pyats/contrib/creators/tests/test_creator.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-from ..creator import TestbedCreator
+from pyats.contrib.creators.creator import TestbedCreator
 from unittest import TestCase, main
 from pyats.topology import Testbed
 from pyats.topology.loader.base import BaseTestbedLoader

--- a/src/pyats/contrib/creators/tests/test_file.py
+++ b/src/pyats/contrib/creators/tests/test_file.py
@@ -9,6 +9,10 @@ from pyats.datastructures import Configuration
 from pyats.utils import secret_strings
 
 class TestFile(TestCase):
+
+    # set default pyats configuration
+    secret_strings.cfg = Configuration()
+
     def setUp(self):
         self.csv_file = ("hostname,ip,username,password,protocol,os,"
         "custom:opt1,custom:opt2\nnx-osv-1,172.25.192.90,admin,admin,"
@@ -83,9 +87,6 @@ class TestFile(TestCase):
                     testbed.devices['nx-osv-1'].credentials.default.username)
 
     def test_encode_password(self):
-        # set default pyats configuration
-        config = Configuration()
-        secret_strings.cfg = config
         File(path=self.test_csv, encode_password=True).to_testbed_file(
                                                                     self.output)
         with open(self.output) as file: 

--- a/src/pyats/contrib/creators/tests/test_file.py
+++ b/src/pyats/contrib/creators/tests/test_file.py
@@ -2,9 +2,11 @@ import os
 import shutil
 import xlwt
 
-from ..file import File
+from pyats.contrib.creators.file import File
 from unittest import TestCase, main
 from pyats.topology import Testbed
+from pyats.datastructures import Configuration
+from pyats.utils import secret_strings
 
 class TestFile(TestCase):
     def setUp(self):
@@ -81,6 +83,9 @@ class TestFile(TestCase):
                     testbed.devices['nx-osv-1'].credentials.default.username)
 
     def test_encode_password(self):
+        # set default pyats configuration
+        config = Configuration()
+        secret_strings.cfg = config
         File(path=self.test_csv, encode_password=True).to_testbed_file(
                                                                     self.output)
         with open(self.output) as file: 

--- a/src/pyats/contrib/creators/tests/test_interactive.py
+++ b/src/pyats/contrib/creators/tests/test_interactive.py
@@ -7,6 +7,8 @@ from pyats.utils import secret_strings
 class TestInteractive(TestCase):
 
     maxDiff = None
+    # set default pyats configuration
+    secret_strings.cfg = Configuration()
 
     @mock.patch('builtins.input')
     @mock.patch('getpass.getpass')
@@ -82,9 +84,6 @@ class TestInteractive(TestCase):
         input_function.side_effect = mock_input
         getpass.return_value = "super"
         output_file = '/tmp/test.yaml'
-        # set default pyats configuration
-        config = Configuration()
-        secret_strings.cfg = config
         Interactive(encode_password=True).to_testbed_file(output_file)
         with open(output_file) as file:
             self.assertEqual(file.read(), expected)

--- a/src/pyats/contrib/creators/tests/test_interactive.py
+++ b/src/pyats/contrib/creators/tests/test_interactive.py
@@ -1,8 +1,13 @@
 from unittest import TestCase, main, mock
-from ..interactive import Interactive
+from pyats.contrib.creators.interactive import Interactive
 from pyats.topology import Testbed
+from pyats.datastructures import Configuration
+from pyats.utils import secret_strings
 
 class TestInteractive(TestCase):
+
+    maxDiff = None
+
     @mock.patch('builtins.input')
     @mock.patch('getpass.getpass')
     def test_interactive(self, getpass, input_function):
@@ -77,6 +82,9 @@ class TestInteractive(TestCase):
         input_function.side_effect = mock_input
         getpass.return_value = "super"
         output_file = '/tmp/test.yaml'
+        # set default pyats configuration
+        config = Configuration()
+        secret_strings.cfg = config
         Interactive(encode_password=True).to_testbed_file(output_file)
         with open(output_file) as file:
             self.assertEqual(file.read(), expected)

--- a/src/pyats/contrib/creators/tests/test_netbox.py
+++ b/src/pyats/contrib/creators/tests/test_netbox.py
@@ -1,5 +1,5 @@
 from unittest import TestCase, main
-from ..netbox import Netbox
+from pyats.contrib.creators.netbox import Netbox
 from pyats.topology import Testbed
 
 class TestNetbox(TestCase):

--- a/src/pyats/contrib/creators/tests/test_template.py
+++ b/src/pyats/contrib/creators/tests/test_template.py
@@ -2,7 +2,8 @@ import xlrd
 
 from unittest import TestCase, main
 from pyats.topology import Testbed
-from ..template import Template
+from pyats.contrib.creators.template import Template
+
 
 class TestTemplate(TestCase):
     test_csv = '/tmp/test.csv'

--- a/src/pyats/contrib/tests/creators
+++ b/src/pyats/contrib/tests/creators
@@ -1,0 +1,1 @@
+../creators/tests


### PR DESCRIPTION
fixed UTs for pyats.contrib. they were erroring when custom secret key is used in pyats.conf. and added symbolic link for `tests` as same as other packages's manner.

```
python -m unittest -v
test_ansible (creators.test_ansible.TestAnsible) ... Using the default encoding key since no key was specified in configuration.
THIS IS A SHARED KEY AND IS NOT SECURE, PLEASE RUN `pyats secret keygen` AND ADD TO YOUR pyats.conf FILE BEFORE ENCODING ANY VALUES.
ok
test_encode_password (creators.test_ansible.TestAnsible) ... Using the default encoding key since no key was specified in configuration.
THIS IS A SHARED KEY AND IS NOT SECURE, PLEASE RUN `pyats secret keygen` AND ADD TO YOUR pyats.conf FILE BEFORE ENCODING ANY VALUES.
ok
test_no_arguments (creators.test_ansible.TestAnsible) ... ok
test_arguments (creators.test_creator.TestCreator) ... ok
test_cli_arguments (creators.test_creator.TestCreator) ... ok
test_cli_list (creators.test_creator.TestCreator) ... ok
test_cli_replacements (creators.test_creator.TestCreator) ... ok
test_generate (creators.test_creator.TestCreator) ... ok
test_inheritance (creators.test_creator.TestCreator) ... ok
test_load (creators.test_creator.TestCreator) ... ok
test_mixed_arguments (creators.test_creator.TestCreator) ... ok
test_output_to_folder (creators.test_creator.TestCreator) ... ok
test_to_testbed_file_none (creators.test_creator.TestCreator) ... ok
test_to_testbed_object (creators.test_creator.TestCreator) ... ok
test_csv_file (creators.test_file.TestFile) ... ok
test_directory (creators.test_file.TestFile) ... ok
test_encode_password (creators.test_file.TestFile) ... ok
test_excel_load (creators.test_file.TestFile) ... ok
test_no_arguments (creators.test_file.TestFile) ... ok
test_add_keys (creators.test_interactive.TestInteractive) ... ok
test_encode_password (creators.test_interactive.TestInteractive) ... ok
test_interactive (creators.test_interactive.TestInteractive) ... ok
test_two_devices (creators.test_interactive.TestInteractive) ... ok
test_missing_arguments (creators.test_netbox.TestNetbox) ... ok
test_add_keys (creators.test_template.TestTemplate) ... ok
test_csv_template (creators.test_template.TestTemplate) ... ok
test_excel_template (creators.test_template.TestTemplate) ... ok
test_to_testbed_object (creators.test_template.TestTemplate) ... ok

----------------------------------------------------------------------
Ran 28 tests in 0.185s

OK