### PR TITLE
FIX device credential

### DIFF
--- a/src/pyats/contrib/creators/netbox.py
+++ b/src/pyats/contrib/creators/netbox.py
@@ -721,6 +721,9 @@ class Netbox(TestbedCreator):
             else:
                 username = self._def_user
                 password  = self._def_pass
+                device_data.setdefault("credentials", {
+                    "default": { "username": username, "password": password }
+                })
 
 
         # If testbed has data, return it


### PR DESCRIPTION
If the def_user and def_pass wasn't None the credentials attribute wasn't been set.