### PR TITLE
removed ansible dependency

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyats[full]
+        pip install pyats[full] ansible
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip uninstall pyats.contrib -y
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,8 +24,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pyats[full] ansible
+        python -m pip install --upgrade pip setuptools wheel
+        pip install pyats[full]
+        pip install ansible
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip uninstall pyats.contrib -y
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ STAGING_PKGS  = /auto/pyats/staging/packages
 STAGING_EXT_PKGS  = /auto/pyats/staging/packages
 
 # xlrd==1.2 because support for '.xlsx' files was dropped in later versions
-DEPENDENCIES = ansible requests requests-toolbelt xlrd==1.2 xlwt xlsxwriter
+DEPENDENCIES = requests requests-toolbelt xlrd==1.2 xlwt xlsxwriter
 
 .PHONY: check help clean test package develop undevelop all \
         install_build_deps uninstall_build_deps distribute_staging\

--- a/docs/changelog/2021/july.rst
+++ b/docs/changelog/2021/july.rst
@@ -1,0 +1,32 @@
+July 2021
+=========
+
+July 27th
+---------
+
+.. csv-table:: Module Versions
+    :header: "Modules", "Versions"
+
+        ``pyats.contrib``, v21.7
+
+
+Install Instructions
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    bash$ pip install pyats.contrib
+
+Upgrade Instructions
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    bash$ pip install --upgrade pyats.contrib
+
+
+Features and Bug Fixes:
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* pyats create testbed ansible
+    * Removed 'ansible' package dependency. Need to install from now on separately

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ setup(
 
     # package dependencies
     install_requires=[
-        "ansible",
         "requests",
         "requests-toolbelt",
         "xlrd==1.2", # xlrd==1.2 because support for '.xlsx' files was dropped in later versions

--- a/src/pyats/contrib/creators/ansible.py
+++ b/src/pyats/contrib/creators/ansible.py
@@ -1,7 +1,10 @@
-from ansible.parsing.dataloader import DataLoader
-from ansible.inventory.manager import InventoryManager
-from ansible.cli.inventory import InventoryCLI
-from ansible import context
+try:
+    from ansible.parsing.dataloader import DataLoader
+    from ansible.inventory.manager import InventoryManager
+    from ansible.cli.inventory import InventoryCLI
+    from ansible import context
+except Exception:
+    raise ImportError("'ansible' package is not installed. Please install by running: pip install ansible")
 from .creator import TestbedCreator
 
 class Ansible(TestbedCreator):


### PR DESCRIPTION
removed ansible package dependency. need to install from now on manually/separately.

if `ansible` is not installed, user will get below message.
```
$ pyats create testbed ansible --output=out --inventory-name=inventory.ini

'ansible' package is not installed. Please install by running: pip install ansible