### PR TITLE
add FirePower support and fix topology code for devices without ip

### DIFF
--- a/src/pyats/contrib/creators/netbox.py
+++ b/src/pyats/contrib/creators/netbox.py
@@ -175,10 +175,14 @@ class Netbox(TestbedCreator):
     
         """
         valid_os = ["com", "asa", "dnac", "ios-xe", "ios-xr",
-            "iosxe", "iosxr", "ios", "junos", "linux", "nxos", "nx-os", "yang"]
+            "iosxe", "iosxr", "ios", "junos", "linux", "nxos", "nx-os", "yang", 
+            "ftd"]
 
         for valid in valid_os:
             if os and valid in os.lower():
+                #ftd is a deprecated platform in pyats, change to fxos
+                if valid == "ftd":
+                   return "fxos"
                 return valid.replace("-", "")
         
         return None
@@ -705,6 +709,7 @@ class Netbox(TestbedCreator):
                 )
                 
                 del data[device_name]
+                del topology[device_name]
                 continue
                 
             if self._def_user is None or self._def_pass is None:


### PR DESCRIPTION
Made some small modifications to the creator code for NetBox.  Devices with 'ftd' in the NetBox platform 'slug' will now be recognized as having os=fxos and will be handled correctly by Unicon.  Also, previously devices without IP were deleted from the data written to the testbed file, but their interface data was retained in the topology section; one line has been added to delete the topology data.