### PR TITLE
String template plugin for pyats create testbed

### DIFF
--- a/src/pyats/contrib/creators/tests/test_yamltemplate.py
+++ b/src/pyats/contrib/creators/tests/test_yamltemplate.py
@@ -7,16 +7,16 @@ class TestYamltemplate(TestCase):
 
     def setUp(self):
         self.tmpl_str = """devices:
-  $device_name:
+  %device_name:
     connections:
       cli:
-        ip: $mgmt_ip
+        ip: %mgmt_ip
         protocol: ssh
     credentials:
       default:
-        username: $username
-        password: $password
-    os: $os
+        username: %username
+        password: %password
+    os: %os
 """
 
         self.template_file = '/tmp/template.yaml'

--- a/src/pyats/contrib/creators/tests/test_yamltemplate.py
+++ b/src/pyats/contrib/creators/tests/test_yamltemplate.py
@@ -1,0 +1,139 @@
+from unittest import TestCase, main, mock
+from pyats.contrib.creators.yamltemplate import Yamltemplate
+from pyats.topology import Testbed
+
+
+class TestYamltemplate(TestCase):
+
+    def setUp(self):
+        self.tmpl_str = """devices:
+  $device_name:
+    connections:
+      cli:
+        ip: $mgmt_ip
+        protocol: ssh
+    credentials:
+      default:
+        username: $username
+        password: $password
+    os: $os
+"""
+
+        self.template_file = '/tmp/template.yaml'
+        with open(self.template_file, 'w') as file:
+            file.write(self.tmpl_str)
+
+        self.expected = """devices:
+  hostname:
+    connections:
+      cli:
+        ip: 123.123.123.123
+        protocol: ssh
+    credentials:
+      default:
+        password: super
+        username: admin
+    os: iosxe
+"""
+
+    @mock.patch('builtins.input')
+    def test_interactive(self, input_function):
+        input_value = ["hostname", "123.123.123.123", "admin", "super", "iosxe"]
+        value = input_value.copy()
+
+        def mock_input(text):
+            return value.pop(0)
+        input_function.side_effect = mock_input
+        output_file = '/tmp/test.yaml'
+        Yamltemplate(template_file=self.template_file).to_testbed_file(output_file)
+        with open(output_file) as file:
+            self.assertEqual(file.read(), self.expected)
+        value = input_value.copy()
+        testbed = Yamltemplate(template_file=self.template_file).to_testbed_object()
+        self.assertTrue(isinstance(testbed, Testbed))
+        self.assertIn('hostname', testbed.devices)
+        self.assertEqual(testbed.devices['hostname'].os, 'iosxe')
+        self.assertIn('cli', testbed.devices['hostname'].connections)
+        self.assertEqual('123.123.123.123',  testbed.devices['hostname'].connections.cli.ip)
+        self.assertEqual('ssh', testbed.devices['hostname'].connections.cli.protocol)
+        self.assertIn('default', testbed.devices['hostname'].credentials)
+        self.assertEqual('admin', testbed.devices['hostname'].credentials.default.username)
+
+    @mock.patch('builtins.input')
+    def test_interactive_with_values_file(self, input_function):
+        input_value = ["", "", "admin", "super", "iosxe"]
+        value = input_value.copy()
+
+        def mock_input(text):
+            return value.pop(0)
+        input_function.side_effect = mock_input
+        values = """device_name: hostname
+mgmt_ip: 123.123.123.123
+"""
+        values_file = '/tmp/values.yaml'
+        with open(values_file, 'w') as file:
+            file.write(values)
+        output_file = '/tmp/test.yaml'
+        Yamltemplate(template_file=self.template_file, value_file=values_file).to_testbed_file(output_file)
+        with open(output_file) as file:
+            self.assertEqual(file.read(), self.expected)
+        value = input_value.copy()
+        testbed = Yamltemplate(template_file=self.template_file, value_file=values_file).to_testbed_object()
+        self.assertTrue(isinstance(testbed, Testbed))
+        self.assertIn('hostname', testbed.devices)
+        self.assertEqual(testbed.devices['hostname'].os, 'iosxe')
+        self.assertIn('cli', testbed.devices['hostname'].connections)
+        self.assertEqual('123.123.123.123',  testbed.devices['hostname'].connections.cli.ip)
+        self.assertEqual('ssh', testbed.devices['hostname'].connections.cli.protocol)
+        self.assertIn('default', testbed.devices['hostname'].credentials)
+        self.assertEqual('admin', testbed.devices['hostname'].credentials.default.username)
+
+    def test_values_file_noprompt(self):
+        values = """device_name: hostname
+mgmt_ip: 123.123.123.123
+username: admin
+password: super
+os: iosxe
+"""
+        values_file = '/tmp/values.yaml'
+        with open(values_file, 'w') as file:
+            file.write(values)
+        output_file = '/tmp/test.yaml'
+        Yamltemplate(template_file=self.template_file,
+                     value_file=values_file,
+                     noprompt=True).to_testbed_file(output_file)
+        with open(output_file) as file:
+            self.assertEqual(file.read(), self.expected)
+        testbed = Yamltemplate(template_file=self.template_file,
+                               value_file=values_file,
+                               noprompt=True).to_testbed_object()
+        self.assertTrue(isinstance(testbed, Testbed))
+        self.assertIn('hostname', testbed.devices)
+        self.assertEqual(testbed.devices['hostname'].os, 'iosxe')
+        self.assertIn('cli', testbed.devices['hostname'].connections)
+        self.assertEqual('123.123.123.123',  testbed.devices['hostname'].connections.cli.ip)
+        self.assertEqual('ssh', testbed.devices['hostname'].connections.cli.protocol)
+        self.assertIn('default', testbed.devices['hostname'].credentials)
+        self.assertEqual('admin', testbed.devices['hostname'].credentials.default.username)
+
+    def test_missing_keys(self):
+        values = """device_name: hostname
+mgmt_ip: 123.123.123.123
+username: admin
+password: super
+"""
+        values_file = '/tmp/values.yaml'
+        with open(values_file, 'w') as file:
+            file.write(values)
+        with self.assertRaises(Exception):
+            Yamltemplate(template_file=self.template_file,
+                         value_file=values_file,
+                         noprompt=True)._generate()
+
+    def test_no_values_file_noprompt(self):
+        with self.assertRaises(Exception):
+            Yamltemplate(template_file=self.template_file, noprompt=True)._generate()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/pyats/contrib/creators/tests/test_yamltemplate.py
+++ b/src/pyats/contrib/creators/tests/test_yamltemplate.py
@@ -157,10 +157,6 @@ os: iosxe
         with open(output_file) as file:
             self.assertEqual(file.read(), self.expected)
 
-    def test_invalid_delimiter(self):
-        with self.assertRaises(Exception):
-            Yamltemplate(template_file=self.template_file, delimiter='$%')._generate()
-
 
 if __name__ == '__main__':
     main()

--- a/src/pyats/contrib/creators/tests/test_yamltemplate.py
+++ b/src/pyats/contrib/creators/tests/test_yamltemplate.py
@@ -7,7 +7,7 @@ class TestYamltemplate(TestCase):
 
     def setUp(self):
         self.tmpl_str = """devices:
-  %device_name:
+  %{device_name}:
     connections:
       cli:
         ip: %mgmt_ip

--- a/src/pyats/contrib/creators/tests/test_yamltemplate.py
+++ b/src/pyats/contrib/creators/tests/test_yamltemplate.py
@@ -134,6 +134,33 @@ password: super
         with self.assertRaises(Exception):
             Yamltemplate(template_file=self.template_file, noprompt=True)._generate()
 
+    def test_delimiter(self):
+        delimiter = '$'
+        template_file = '/tmp/template2.yaml'
+        with open(template_file, 'w') as file:
+            file.write(self.tmpl_str.replace('%', delimiter))
+
+        values = """device_name: hostname
+mgmt_ip: 123.123.123.123
+username: admin
+password: super
+os: iosxe
+"""
+        values_file = '/tmp/values.yaml'
+        with open(values_file, 'w') as file:
+            file.write(values)
+        output_file = '/tmp/test.yaml'
+        Yamltemplate(template_file=template_file,
+                     value_file=values_file,
+                     noprompt=True,
+                     delimiter=delimiter).to_testbed_file(output_file)
+        with open(output_file) as file:
+            self.assertEqual(file.read(), self.expected)
+
+    def test_invalid_delimiter(self):
+        with self.assertRaises(Exception):
+            Yamltemplate(template_file=self.template_file, delimiter='$%')._generate()
+
 
 if __name__ == '__main__':
     main()

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -4,8 +4,6 @@ import yaml
 
 from .creator import TestbedCreator
 
-class CustomTemplate(string.Template):
-    delimiter = '%'
 
 class Yamltemplate(TestbedCreator):
     """ Yamltemplate class (TestbedCreator)
@@ -90,7 +88,7 @@ class Yamltemplate(TestbedCreator):
         with open(self._template_file, 'r') as f:
             tmpl_str = f.read()
 
-        tmpl = CustomTemplate(tmpl_str)
+        tmpl = type('CustomTemplate', (string.Template, object), {'delimiter': '%'})(tmpl_str)
 
         kwargs = {}
         if self._value_file:

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -93,7 +93,6 @@ class Yamltemplate(TestbedCreator):
 
         if not self._noprompt:
             keys = [s[1] or s[2] for s in tmpl.pattern.findall(tmpl_str) if s[1] or s[2]]
-            print(keys)
             for key in list(dict.fromkeys(keys)):
                 if key in kwargs:
                     kwargs[key] = self._get_info(f'{key} ({kwargs[key]}): ', default=kwargs[key])

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -20,12 +20,15 @@ class Yamltemplate(TestbedCreator):
             to be populated in the template.
         noprompt ('boolean') default=False: If specified, the user will not be prompted
             to override the default values from the value_file.
+        delimiter ('str') default='%': If specified, uses the provided character as the
+            string template delimiter (must be a single character).
 
     CLI Argument          |  Class Argument
     ---------------------------------------------
     --template-file=value |  template_file=value
     --value-file=value    |  value_file=value
     --noprompt            |  noprompt=True
+    --delimiter=value     |  delimiter=True
 
     pyATS Examples:
         pyats create testbed yamltemplate --template-file=temp.yaml --output=testbed.yaml
@@ -53,6 +56,7 @@ class Yamltemplate(TestbedCreator):
             'optional': {
                 'value_file': None,
                 'noprompt': False,
+                'delimiter': '%'
             }
         }
 
@@ -85,10 +89,13 @@ class Yamltemplate(TestbedCreator):
         if self._noprompt and not self._value_file:
             raise Exception('noprompt option requires a value file to be specified')
 
+        if len(self._delimiter) != 1:
+            raise Exception(f'Invalid delimiter "{self._delimiter}" (must be a single character)')
+
         with open(self._template_file, 'r') as f:
             tmpl_str = f.read()
 
-        tmpl = type('CustomTemplate', (string.Template, object), {'delimiter': '%'})(tmpl_str)
+        tmpl = type('CustomTemplate', (string.Template, object), {'delimiter': self._delimiter})(tmpl_str)
 
         kwargs = {}
         if self._value_file:

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -10,7 +10,8 @@ class Yamltemplate(TestbedCreator):
 
     Creator for the 'yamltemplate' source. Takes in a YAML file with $-based identifiers
     (as described in PEP 292). Prompts for input for each identifier, substitutes the given
-    values, and outputs the resulting YAML file.
+    values, and outputs the resulting YAML file. Can optionally take a list of values from
+    a second YAML file, and prompt the user to override them if desired.
 
     Args:
         template_file ('str'): The path of the input YAML template file.
@@ -27,6 +28,10 @@ class Yamltemplate(TestbedCreator):
 
     pyATS Examples:
         pyats create testbed yamltemplate --template-file=temp.yaml --output=testbed.yaml
+        pyats create testbed yamltemplate --template-file=temp.yaml --value-file values.yaml
+            --output=testbed.yaml
+        pyats create testbed yamltemplate --template-file=temp.yaml --value-file values.yaml
+            --output=testbed.yaml --noprompt
 
     Examples:
         # Create testbed from test.csv with encoded password

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -4,14 +4,17 @@ import yaml
 
 from .creator import TestbedCreator
 
+class CustomTemplate(string.Template):
+    delimiter = '%'
 
 class Yamltemplate(TestbedCreator):
     """ Yamltemplate class (TestbedCreator)
 
-    Creator for the 'yamltemplate' source. Takes in a YAML file with $-based identifiers
-    (as described in PEP 292). Prompts for input for each identifier, substitutes the given
-    values, and outputs the resulting YAML file. Can optionally take a list of values from
-    a second YAML file, and prompt the user to override them if desired.
+    Creator for the 'yamltemplate' source. Takes in a YAML file containing template strings
+    as described in PEP 292, but using % as the delimiter (rather than $). Prompts for input
+    for each identifier, substitutes the given values, and outputs the resulting YAML file.
+    Can optionally take a list of values from a second YAML file, and prompt the user to
+    override them if desired.
 
     Args:
         template_file ('str'): The path of the input YAML template file.
@@ -87,7 +90,7 @@ class Yamltemplate(TestbedCreator):
         with open(self._template_file, 'r') as f:
             tmpl_str = f.read()
 
-        tmpl = string.Template(tmpl_str)
+        tmpl = CustomTemplate(tmpl_str)
 
         kwargs = {}
         if self._value_file:

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -2,8 +2,8 @@ import os
 import string
 import yaml
 
-from pyats.topology import loader
 from .creator import TestbedCreator
+
 
 class Yamltemplate(TestbedCreator):
     """ Yamltemplate class (TestbedCreator)
@@ -71,7 +71,6 @@ class Yamltemplate(TestbedCreator):
         while not response:
             response = input(msg) or default
         return response
-
 
     def _generate(self):
         """ Core implementation of how the testbed data is created.

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -78,6 +78,9 @@ class Yamltemplate(TestbedCreator):
         if not os.path.exists(self._template_file):
             raise FileNotFoundError(f'File does not exist: {self._template_file}')
 
+        if self._noprompt and not self._value_file:
+            raise Exception('noprompt option requires a value file to be specified')
+
         with open(self._template_file, 'r') as f:
             tmpl_str = f.read()
 
@@ -97,6 +100,9 @@ class Yamltemplate(TestbedCreator):
                 else:
                     kwargs[key] = self._get_info(f'{key}: ')
 
-        sub = tmpl.substitute(kwargs)
+        try:
+            sub = tmpl.substitute(kwargs)
+        except KeyError as e:
+            raise Exception(f'No value found for key "{e.args[0]}"')
         clean_yaml = yaml.safe_load(sub)
         return clean_yaml

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -34,7 +34,6 @@ class Yamltemplate(TestbedCreator):
             --output=testbed.yaml --noprompt
 
     Examples:
-        # Create testbed from test.csv with encoded password
         creator = Yamltemplate(template_file="temp.yaml")
         creator.to_testbed_file("testbed.yaml")
         creator.to_testbed_object()
@@ -96,7 +95,9 @@ class Yamltemplate(TestbedCreator):
                 kwargs = yaml.safe_load(f)
 
         if not self._noprompt:
+            # Find all keys from template file
             keys = [s[1] or s[2] for s in tmpl.pattern.findall(tmpl_str) if s[1] or s[2]]
+            # Ignore duplicate keys
             for key in list(dict.fromkeys(keys)):
                 if key in kwargs:
                     kwargs[key] = self._get_info(f'{key} ({kwargs[key]}): ', default=kwargs[key])

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -20,8 +20,8 @@ class Yamltemplate(TestbedCreator):
             to be populated in the template.
         noprompt ('boolean') default=False: If specified, the user will not be prompted
             to override the default values from the value_file.
-        delimiter ('str') default='%': If specified, uses the provided character as the
-            string template delimiter (must be a single character).
+        delimiter ('str') default='%': If specified, uses the provided string as the
+            string template delimiter.
 
     CLI Argument          |  Class Argument
     ---------------------------------------------
@@ -88,9 +88,6 @@ class Yamltemplate(TestbedCreator):
 
         if self._noprompt and not self._value_file:
             raise Exception('noprompt option requires a value file to be specified')
-
-        if len(self._delimiter) != 1:
-            raise Exception(f'Invalid delimiter "{self._delimiter}" (must be a single character)')
 
         with open(self._template_file, 'r') as f:
             tmpl_str = f.read()

--- a/src/pyats/contrib/creators/yamltemplate.py
+++ b/src/pyats/contrib/creators/yamltemplate.py
@@ -1,0 +1,101 @@
+import os
+import string
+import yaml
+
+from pyats.topology import loader
+from .creator import TestbedCreator
+
+class Yamltemplate(TestbedCreator):
+    """ Yamltemplate class (TestbedCreator)
+
+    Creator for the 'yamltemplate' source. Takes in a YAML file with $-based identifiers
+    (as described in PEP 292). Prompts for input for each identifier, substitutes the given
+    values, and outputs the resulting YAML file.
+
+    Args:
+        path ('str'): The path of the input YAML template file.
+        values ('str'): The path of a YAML file contains key-value pairs to be populated in the template.
+        noprompt ('boolean'): If specified, the user will not be prompted to override the default values
+                              from the values file.
+
+    CLI Argument        |  Class Argument
+    ---------------------------------------------
+    --path=value        |  path=value
+    --values=value      |  values=value
+    --noprompt          |  noprompt=True
+
+    pyATS Examples:
+        pyats create testbed yamltemplate --path=temp.yaml --output=testbed.yaml
+
+    Examples:
+        # Create testbed from test.csv with encoded password
+        creator = Yamltemplate(path="temp.yaml")
+        creator.to_testbed_file("testbed.yaml")
+        creator.to_testbed_object()
+
+    """
+
+    def _init_arguments(self):
+        """ Specifies the arguments for the creator.
+
+        Returns:
+            dict: Arguments for the creator.
+
+        """
+        return {
+            'required': ['path'],
+            'optional': {
+                'values': None,
+                'noprompt': False,
+            }
+        }
+
+    def _get_info(self, msg, default=''):
+        """ Prompts input from user, validating the input if iterable is
+            provided.
+
+        Args:
+            msg ('str'): The prompt message.
+            iterable ('iterable'): Iterable object that contains the
+                valid/invalid answers.
+            invalid ('bool'): Flag that tells if iterable is invalid answer.
+
+        Returns:
+            str: The user's input.
+
+        """
+        response = ''
+        while not response:
+            response = input(msg) or default
+        return response
+
+
+    def _generate(self):
+        """ Core implementation of how the testbed data is created.
+
+        Returns:
+            dict: The intermediate testbed dictionary.
+
+        """
+        if not os.path.exists(self._path):
+            raise FileNotFoundError(f'File does not exist: {self._path}')
+
+        with open(self._path, 'r') as f:
+            tmpl = f.read()
+
+        kwargs = {}
+        if self._values:
+            with open(self._values, 'r') as f:
+                kwargs = yaml.safe_load(f)
+
+        if not self._noprompt:
+            keys = [ele[1] for ele in string.Formatter().parse(tmpl) if ele[1]]
+            for key in list(dict.fromkeys(keys)):
+                if key in kwargs:
+                    kwargs[key] = self._get_info(f'{key} ({kwargs[key]}): ', default=kwargs[key])
+                else:
+                    kwargs[key] = self._get_info(f'{key}: ')
+
+        sub = string.Template(tmpl).substitute(kwargs)
+        clean_yaml = yaml.safe_load(sub)
+        return clean_yaml


### PR DESCRIPTION
Plugin for `pyats create testbed` that allows the user to define a template with a particular structure for a testbed file, and use string templating to populate specific values.  This allows the creation of more complex testbed files, rather than being limited to a single connection per device.

The plugin determines the keys from the template file, and prompts the user for the values.  Or, a second file can optionally be supplied that contains the values to use.  In this case the user will still be prompted, but the value from the file will be used if they don't enter anything.

A `--noprompt` option is also provided to take input only from the value file.

Example invocation:
```
$ pyats create testbed yamltemplate --output testbed.yaml --template-file temp.yaml
device_name: mydevice
mgmt_ip: 1.2.3.4
username: testuser
password: testpassword
os: iosxe
Testbed file generated: 
testbed.yaml
```
With optional values file:
```
$ pyats create testbed yamltemplate --output testbed.yaml --template-file temp.yaml --value-file values.yaml
device_name (mydevice): 
mgmt_ip (1.2.3.4): 
username (testuser): 
password (testpassword): 
os (iosxe): 
Testbed file generated: 
testbed.yaml 
```
With noprompt option:
```
$ pyats create testbed yamltemplate --output testbed.yaml --template-file temp.yaml --value-file values.yaml --noprompt
Testbed file generated: 
testbed.yaml 
```
Files used for the above:

<details>
<summary>temp.yaml</summary>

```
devices:
  $device_name:
    connections:
      cli:
        ip: $mgmt_ip
        protocol: ssh
    credentials:
      default:
        username: $username
        password: $password
    os: $os
```

</details>

<details>
<summary>values.yaml</summary>

```
device_name: mydevice
mgmt_ip: 1.2.3.4
username: testuser
password: testpassword
os: iosxe
```

</details>
<details>
<summary>testbed.yaml</summary>

```
devices:
  mydevice:
    connections:
      cli:
        ip: 1.2.3.4
        protocol: ssh
    credentials:
      default:
        password: testpassword
        username: testuser
    os: iosxe
```

</details>

Unit tests:
<details>
<summary>Unit test output</summary>

```
$ python -m unittest -v
test_ansible (tests.test_ansible.TestAnsible) ... skipped 'ansible package is not installed'
test_encode_password (tests.test_ansible.TestAnsible) ... skipped 'ansible package is not installed'
test_no_arguments (tests.test_ansible.TestAnsible) ... skipped 'ansible package is not installed'
test_arguments (tests.test_creator.TestCreator) ... ok
test_cli_arguments (tests.test_creator.TestCreator) ... ok
test_cli_list (tests.test_creator.TestCreator) ... ok
test_cli_replacements (tests.test_creator.TestCreator) ... ok
test_generate (tests.test_creator.TestCreator) ... ok
test_inheritance (tests.test_creator.TestCreator) ... ok
test_load (tests.test_creator.TestCreator) ... ok
test_mixed_arguments (tests.test_creator.TestCreator) ... ok
test_output_to_folder (tests.test_creator.TestCreator) ... ok
test_to_testbed_file_none (tests.test_creator.TestCreator) ... ok
test_to_testbed_object (tests.test_creator.TestCreator) ... ok
test_csv_file (tests.test_file.TestFile) ... ok
test_directory (tests.test_file.TestFile) ... ok
test_encode_password (tests.test_file.TestFile) ... ok
test_excel_load (tests.test_file.TestFile) ... ok
test_no_arguments (tests.test_file.TestFile) ... ok
test_add_keys (tests.test_interactive.TestInteractive) ... ok
test_encode_password (tests.test_interactive.TestInteractive) ... ok
test_interactive (tests.test_interactive.TestInteractive) ... ok
test_two_devices (tests.test_interactive.TestInteractive) ... ok
test_missing_arguments (tests.test_netbox.TestNetbox) ... ok
test_add_keys (tests.test_template.TestTemplate) ... ok
test_csv_template (tests.test_template.TestTemplate) ... ok
test_excel_template (tests.test_template.TestTemplate) ... ok
test_to_testbed_object (tests.test_template.TestTemplate) ... ok
test_interactive (tests.test_yamltemplate.TestYamltemplate) ... ok
test_interactive_with_values_file (tests.test_yamltemplate.TestYamltemplate) ... ok
test_missing_keys (tests.test_yamltemplate.TestYamltemplate) ... ok
test_no_values_file_noprompt (tests.test_yamltemplate.TestYamltemplate) ... ok
test_values_file_noprompt (tests.test_yamltemplate.TestYamltemplate) ... ok

----------------------------------------------------------------------
Ran 33 tests in 0.133s

OK (skipped=3)
```

</details>