### PR TITLE
Fix netbox verify argument type error

### DIFF
--- a/src/pyats/contrib/creators/creator.py
+++ b/src/pyats/contrib/creators/creator.py
@@ -136,7 +136,6 @@ class TestbedCreator(BaseTestbedLoader):
                 # Convert key to variable name
                 key = key.replace('--', '')
                 key = key.replace('-', '_')
-
                 kwargs.setdefault(key, value)
 
         return kwargs

--- a/src/pyats/contrib/creators/creator.py
+++ b/src/pyats/contrib/creators/creator.py
@@ -4,6 +4,7 @@ import re
 import logging
 import sys
 import argparse
+import ast
 
 from pyats.utils.secret_strings import SecretString
 from pyats.topology.loader.base import BaseTestbedLoader
@@ -136,6 +137,11 @@ class TestbedCreator(BaseTestbedLoader):
                 # Convert key to variable name
                 key = key.replace('--', '')
                 key = key.replace('-', '_')
+
+                # For argument 'verify', evaluate value of type String to type Boolean
+                if key == "verify":
+                    value = ast.literal_eval(value)
+
                 kwargs.setdefault(key, value)
 
         return kwargs

--- a/src/pyats/contrib/creators/creator.py
+++ b/src/pyats/contrib/creators/creator.py
@@ -4,7 +4,6 @@ import re
 import logging
 import sys
 import argparse
-import ast
 
 from pyats.utils.secret_strings import SecretString
 from pyats.topology.loader.base import BaseTestbedLoader
@@ -137,10 +136,6 @@ class TestbedCreator(BaseTestbedLoader):
                 # Convert key to variable name
                 key = key.replace('--', '')
                 key = key.replace('-', '_')
-
-                # For argument 'verify', evaluate value of type String to type Boolean
-                if key == "verify":
-                    value = ast.literal_eval(value)
 
                 kwargs.setdefault(key, value)
 

--- a/src/pyats/contrib/creators/netbox.py
+++ b/src/pyats/contrib/creators/netbox.py
@@ -576,6 +576,9 @@ class Netbox(TestbedCreator):
                     "password": self._def_enable
                 }
             
+        # If 'self._verify' is of type 'String', then change it from 'String' to type 'Boolean'
+        if isinstance(self._verify, str):
+            self._verify = True if self._verify == "True" else False
 
         response = [] 
         netbox_endpoints = ["dcim/devices", "virtualization/virtual-machines"]


### PR DESCRIPTION
### Summary
Fix for Issue No. [#74](https://github.com/CiscoTestAutomation/pyats.contrib/issues/74)

### Description
If the argument `--verify` is passed in the command line, it is parsed as a string and passed down to the `_get_request` method of `Netbox` class available in `netbox.py` file where we get the error `TypeError: 'NoneType' object is not iterable`



